### PR TITLE
♻️ refactor(words): Élimination complète des adaptations dans WordsService

### DIFF
--- a/src/dictionary/services/word-services/word-core.service.ts
+++ b/src/dictionary/services/word-services/word-core.service.ts
@@ -147,16 +147,22 @@ export class WordCoreService {
     status = 'approved',
     language?: string,
     categoryId?: string,
-  ): Promise<{ words: Word[]; total: number; page: number; limit: number }> {
+  ): Promise<{ words: Word[]; total: number; page: number; limit: number; totalPages: number }> {
     return DatabaseErrorHandler.handleFindOperation(
       async () => {
-        return this.wordRepository.findAll({
+        const result = await this.wordRepository.findAll({
           page,
           limit,
           status,
           language,
           categoryId,
         });
+        
+        // PHASE 2-1: Calcul de totalPages intégré dans le service core
+        return {
+          ...result,
+          totalPages: Math.ceil(result.total / result.limit),
+        };
       },
       'WordCore',
     );

--- a/src/dictionary/services/word-services/word-permission.service.ts
+++ b/src/dictionary/services/word-services/word-permission.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, ForbiddenException, BadRequestException } from '@nestjs/common';
+import { Injectable, ForbiddenException, BadRequestException, Inject, forwardRef } from '@nestjs/common';
 import { User, UserRole } from '../../../users/schemas/user.schema';
 import { CreateWordDto } from '../../dto/create-word.dto';
 import { UpdateWordDto } from '../../dto/update-word.dto';
 import { Word } from '../../schemas/word.schema';
 import { IWordPermissionService } from '../../interfaces/word-permission.interface';
+import { WordCoreService } from './word-core.service';
 
 /**
  * Implémentation du service de permissions pour les mots
@@ -11,6 +12,11 @@ import { IWordPermissionService } from '../../interfaces/word-permission.interfa
  */
 @Injectable()
 export class WordPermissionService implements IWordPermissionService {
+  
+  constructor(
+    @Inject(forwardRef(() => WordCoreService))
+    private wordCoreService: WordCoreService
+  ) {}
 
   /**
    * Valide qu'un utilisateur peut créer un mot
@@ -60,24 +66,84 @@ export class WordPermissionService implements IWordPermissionService {
 
   /**
    * Vérifie si un utilisateur peut éditer un mot spécifique
+   * PHASE 2-1: Refactoring - Logique complète extraite de words.service.ts
    */
   async canUserEditWord(word: Word, user: User): Promise<boolean> {
-    // Administrateurs peuvent tout éditer
-    if (this.isAdminUser(user)) {
+    console.log("=== DEBUG WordPermissionService.canUserEditWord ===");
+    console.log("Word:", {
+      id: word._id,
+      word: word.word,
+      createdBy: word.createdBy,
+      status: word.status,
+    });
+    console.log("User:", {
+      _id: user._id,
+      username: user.username,
+      role: user.role,
+    });
+
+    // Administrateurs et super-administrateurs peuvent tout éditer
+    if (user.role === UserRole.ADMIN || user.role === UserRole.SUPERADMIN) {
+      console.log("✅ User is admin/superadmin, allowing edit");
       return true;
     }
 
-    // Créateur peut éditer son propre mot
-    if (word.createdBy?.toString() === user._id?.toString()) {
+    // Vérifications de base
+    if (!word.createdBy || word.status === "rejected") {
+      console.log("❌ No createdBy or word is rejected");
+      return false;
+    }
+
+    // Gérer le cas où createdBy est un ObjectId (string) ou un objet User peuplé
+    let createdByIdToCompare: string;
+    if (typeof word.createdBy === "object" && "_id" in word.createdBy) {
+      // createdBy est un objet User peuplé
+      createdByIdToCompare = String(word.createdBy._id);
+      console.log("🔍 createdBy is User object, ID:", createdByIdToCompare);
+    } else {
+      // createdBy est juste un ObjectId (string)
+      createdByIdToCompare = String(word.createdBy);
+      console.log("🔍 createdBy is ObjectId string, ID:", createdByIdToCompare);
+    }
+
+    const userIdToCompare = String(user._id);
+    console.log("🔍 Comparing IDs:", {
+      createdByIdToCompare,
+      userIdToCompare,
+      areEqual: createdByIdToCompare === userIdToCompare,
+    });
+
+    const canEdit = createdByIdToCompare === userIdToCompare;
+    
+    // Contributeurs peuvent aussi éditer les mots en attente
+    if (!canEdit && user.role === UserRole.CONTRIBUTOR && word.status === 'pending') {
+      console.log("✅ Contributor can edit pending word");
       return true;
     }
 
-    // Contributeurs peuvent éditer les mots en attente
-    if (user.role === UserRole.CONTRIBUTOR && word.status === 'pending') {
-      return true;
-    }
+    console.log("✅ Can edit result:", canEdit);
+    console.log("=== END DEBUG WordPermissionService.canUserEditWord ===");
 
-    return false;
+    return canEdit;
+  }
+
+  /**
+   * Vérifie si un utilisateur peut éditer un mot par son ID
+   * PHASE 2-1: Méthode de convenance qui récupère le mot et délègue vers canUserEditWord
+   */
+  async canUserEditWordById(wordId: string, user: User): Promise<boolean> {
+    try {
+      const word = await this.wordCoreService.findOne(wordId);
+      if (!word) {
+        console.log("❌ Word not found");
+        return false;
+      }
+      
+      return this.canUserEditWord(word, user);
+    } catch (error) {
+      console.log("❌ Error checking word permissions:", error);
+      return false;
+    }
   }
 
   /**


### PR DESCRIPTION
• Délégation complète de canUserEditWord vers WordPermissionService • Intégration de totalPages dans WordCoreService pour éliminer adaptations • Harmonisation des interfaces audio pour éliminer transformations • WordsService passe de 716 à 605 lignes (-111 lignes, -15.5%)

Détails techniques:
- canUserEditWord: logique complexe (64 lignes) → simple délégation (3 lignes)
- findAll/getAdminPendingWords: calcul totalPages intégré dans WordCoreService
- bulkUpdateAudioFiles: interface harmonisée sans adaptation de paramètres
- getOptimizedAudioUrl: interface unifiée retournant objet complet
- validateWordAudioFiles: suppression transformation complexe (47 lignes)

Impact: WordsService devient orchestrateur pur sans logique métier.