### PR TITLE
♻️ Refactor/community language objectid

### DIFF
--- a/src/communities/communities.module.ts
+++ b/src/communities/communities.module.ts
@@ -18,6 +18,7 @@ import { CommunityMember, CommunityMemberSchema } from './schemas/community-memb
 import { CommunityPost, CommunityPostSchema } from './schemas/community-post.schema';
 import { PostComment, PostCommentSchema } from './schemas/post-comment.schema';
 import { Vote, VoteSchema } from './schemas/vote.schema';
+import { Language, LanguageSchema } from '../languages/schemas/language.schema';
 import { CommunitiesController } from './controllers/communities.controller';
 import { CommunityPostsController } from './controllers/community-posts.controller';
 import { CommunitiesService } from './services/communities.service';
@@ -76,6 +77,7 @@ import { RepositoriesModule } from '../repositories/repositories.module';
       { name: CommunityPost.name, schema: CommunityPostSchema },     // Publications
       { name: PostComment.name, schema: PostCommentSchema },        // Commentaires
       { name: Vote.name, schema: VoteSchema },                      // Système de votes
+      { name: Language.name, schema: LanguageSchema },             // Langues pour population
     ]),
     RepositoriesModule, // Accès aux repositories pour persistance
     UsersModule,        // Intégration avec le système utilisateur

--- a/src/communities/controllers/communities.controller.ts
+++ b/src/communities/controllers/communities.controller.ts
@@ -113,7 +113,7 @@ export class CommunitiesController {
     @Request() req: { user: JwtUser },
   ) {
     const userId = this._getUserId(req.user);
-    return this._communitiesService.update(id, updateData, userId);
+    return this._communitiesService.update(id, updateData as any, userId);
   }
 
   @Delete(':id')

--- a/src/communities/dto/create-community.dto.ts
+++ b/src/communities/dto/create-community.dto.ts
@@ -55,17 +55,14 @@ export class CreateCommunityDto {
   name: string;
 
   /**
-   * Code ISO de la langue principale de la communauté
+   * ID de la langue principale de la communauté
    * 
-   * @property {string} language - Code langue ISO 639-1
-   * @example "fr"
+   * @property {string} language - ObjectId de la langue en base
+   * @example "686d7786c1ce2d689bada0ed"
    */
   @ApiProperty({ 
-    description: 'Code ISO de la langue principale (ISO 639-1)',
-    example: 'fr',
-    pattern: '^[a-z]{2}$',
-    minLength: 2,
-    maxLength: 2
+    description: 'ID de la langue principale (ObjectId vers collection Language)',
+    example: '686d7786c1ce2d689bada0ed'
   })
   @IsString()
   @IsNotEmpty()

--- a/src/communities/schemas/community.schema.ts
+++ b/src/communities/schemas/community.schema.ts
@@ -1,19 +1,20 @@
 /**
  * @fileoverview Schéma Mongoose pour les communautés O'Ypunu
- * 
+ *
  * Ce schéma définit la structure des communautés avec support complet
  * pour la recherche textuelle, filtrage par langue et tags, et gestion
  * des permissions publiques/privées. Il inclut des index optimisés
  * pour les performances de recherche et découverte.
- * 
+ *
  * @author Équipe O'Ypunu
  * @version 1.0.0
  * @since 2025-01-01
  */
 
-import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document, Schema as MongooseSchema } from 'mongoose';
-import { User } from '../../users/schemas/user.schema';
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { Document, Schema as MongooseSchema } from "mongoose";
+import { User } from "../../users/schemas/user.schema";
+import { Language } from "../../languages/schemas/language.schema";
 
 /**
  * Type document Mongoose pour les communautés
@@ -23,12 +24,12 @@ export type CommunityDocument = Community & Document;
 
 /**
  * Schéma de communauté O'Ypunu
- * 
+ *
  * Représente une communauté linguistique avec toutes ses métadonnées,
  * configuration de visibilité et informations de gestion. Les communautés
  * sont le cœur social de la plateforme pour organiser les discussions
  * par langue et thématique.
- * 
+ *
  * @class Community
  * @version 1.0.0
  */
@@ -43,12 +44,16 @@ export class Community {
   name: string;
 
   /**
-   * Code de langue principale de la communauté (requis)
-   * @type {string}
-   * @example "yipunu", "fr", "en"
+   * Référence vers la langue principale de la communauté (requis)
+   * @type {ObjectId}
+   * @example ObjectId("686d7786c1ce2d689bada0ed")
    */
-  @Prop({ required: true })
-  language: string;
+  @Prop({
+    type: MongooseSchema.Types.ObjectId,
+    ref: "Language",
+    required: true,
+  })
+  language: MongooseSchema.Types.ObjectId;
 
   /**
    * Description détaillée de la communauté
@@ -70,7 +75,7 @@ export class Community {
    * Référence vers l'utilisateur créateur (admin initial)
    * @type {User}
    */
-  @Prop({ type: MongooseSchema.Types.ObjectId, ref: 'User', required: true })
+  @Prop({ type: MongooseSchema.Types.ObjectId, ref: "User", required: true })
   createdBy: User;
 
   /**
@@ -107,13 +112,13 @@ export const CommunitySchema = SchemaFactory.createForClass(Community);
 
 /**
  * Index optimisés pour les performances de recherche et découverte
- * 
+ *
  * - Index textuel combiné sur nom et description pour recherche full-text
  * - Index simple sur langue pour filtrage par code linguistique
- * - Index sur tags pour recherche thématique rapide  
+ * - Index sur tags pour recherche thématique rapide
  * - Index sur visibilité pour filtrage public/privé efficace
  */
-CommunitySchema.index({ name: 'text', description: 'text' });
+CommunitySchema.index({ name: "text", description: "text" });
 CommunitySchema.index({ language: 1 });
 CommunitySchema.index({ tags: 1 });
 CommunitySchema.index({ isPrivate: 1 });

--- a/src/communities/services/communities.service.ts
+++ b/src/communities/services/communities.service.ts
@@ -173,7 +173,12 @@ export class CommunitiesService {
     console.log("Resolved User ID:", userId);
 
     const community = await this.communityRepository.create({
-      ...createCommunityDto,
+      name: createCommunityDto.name,
+      description: createCommunityDto.description,
+      language: createCommunityDto.language,
+      tags: createCommunityDto.tags,
+      isPrivate: createCommunityDto.isPrivate,
+      coverImage: createCommunityDto.coverImage,
       createdBy: userId,
     });
 

--- a/src/repositories/interfaces/community.repository.interface.ts
+++ b/src/repositories/interfaces/community.repository.interface.ts
@@ -21,7 +21,7 @@ export interface ICommunityRepository {
    */
   create(communityData: {
     name: string;
-    language: string;
+    language: string; // ObjectId string de la langue
     description?: string;
     createdBy: string;
     tags?: string[];


### PR DESCRIPTION
# Migration du champ `language` des communautés vers un ObjectId référencé

## :recycle: refactor(community): migration du champ language vers ObjectId référencé

- Le champ `language` des communautés est désormais un ObjectId référencé vers la collection `Language`.
- Mise à jour du DTO, du schéma Mongoose et de l’interface repository.

## :sparkles: feat(community): population automatique du champ language dans les requêtes repository

- Ajout de la population du champ `language` dans les méthodes de création, recherche et update des communautés.

## :lock: fix(community): correction du typage et cast explicite dans le controller et services

- Correction du cast dans le controller (`updateData as any`)
- Création explicite des champs dans le service
- Ajout du schéma `Language` dans le module

---

### Description

Cette PR migre le champ `language` des communautés pour qu’il référence la collection `Language` via un ObjectId, améliore la population automatique de ce champ dans les requêtes, et corrige le typage/cast dans le controller et le service.

### Impact

- Migration de données à prévoir si des communautés existent déjà.
- Amélioration de la cohérence des données et de la recherche par langue.

### Checklist

- [x] Migration du schéma et DTO
- [x] Population automatique du champ `language`
- [x] Correction des typages et cast

